### PR TITLE
Fix mutatingwebhookconfiguration example to support kubernetes version >= 1.22

### DIFF
--- a/examples/mutatingwebhookconfiguration.yaml
+++ b/examples/mutatingwebhookconfiguration.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: namespace-node-affinity
@@ -19,6 +19,7 @@ webhooks:
         apiGroups: [""]
         apiVersions: ["v1"]
         resources: ["pods"]
+    admissionReviewVersions: ["v1"]
     sideEffects: None
     timeoutSeconds: 5
     reinvocationPolicy: Never


### PR DESCRIPTION
In version 1.22, Kubernetes removed beta API `admissionregistration.k8s.io/v1beta1` API versions and introduced `admissionregistration.k8s.io/v1`

https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/