### PR TITLE
fix: handle case where we add NodeSelectorTerms to existing list

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,7 @@ github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/J
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/hudl/fargo v1.3.0/go.mod h1:y3CKSmjA+wD2gak7sUSXTAoopbhU08POFhmITJgmKTg=
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
+github.com/imdario/mergo v0.3.5 h1:JboBksRwiiAJWvIYJVo46AfV+IAIKZpfrSzVKj42R4Q=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=

--- a/injector/injector.go
+++ b/injector/injector.go
@@ -271,7 +271,6 @@ func buildPatch(config *NamespaceConfig, podSpec corev1.PodSpec) ([]byte, error)
 			patches = append(patches, initPatch)
 		}
 
-		// todo: extract this so it is easier to test
 		for _, NodeSelectorTerm := range config.NodeSelectorTerms {
 			nodeSelectorTermsPatch := buildNodeSelectorTermPatch(AddToNodeSelectorTerms, NodeSelectorTerm)
 
@@ -280,7 +279,6 @@ func buildPatch(config *NamespaceConfig, podSpec corev1.PodSpec) ([]byte, error)
 	}
 
 	if config.Tolerations != nil {
-		// todo: handle adding tolerations to an existing array
 		tolerationsPatchPath := buildTolerationsPath(podSpec)
 		for _, toleration := range config.Tolerations {
 			tolerationsPatch := JSONPatch{

--- a/injector/injector_test.go
+++ b/injector/injector_test.go
@@ -204,18 +204,8 @@ func TestBuildNodeSelectorTermPatch(t *testing.T) {
 	assert.Equal(t, patch, expectedPatch)
 }
 
-func TestBuildNodeSelctorTermsInitPatch(t *testing.T) {
+func TestBuildNodeSelectorTermsInitPatch(t *testing.T) {
 	t.Parallel()
-
-	//podSpecWithEmptyNodeSelectorTerms := corev1.PodSpec{
-	//	Affinity: &corev1.Affinity{
-	//		NodeAffinity: &corev1.NodeAffinity{
-	//			RequiredDuringSchedulingIgnoredDuringExecution: &corev1.NodeSelector{
-	//				NodeSelectorTerms: []corev1.NodeSelectorTerm{},
-	//			},
-	//		},
-	//	},
-	//}
 
 	testCases := []struct {
 		name          string
@@ -295,8 +285,6 @@ func TestBuildNodeSelctorTermsInitPatch(t *testing.T) {
 		})
 	}
 }
-
-// todo: TestBuildNodeSelectorTermsInitPatch where the patch path is invalid?
 
 func TestMutateWithInvalidBody(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
fix: handle case where we add NodeSelectorTerms to existing list

Prior to this fix, the injecting NodeSelectorTerms on a Pod that already had some specified would result in the new NodeSelectorTerms being nested one extra level in the array.  For example, running on this pod:

```
apiVersion: v1
kind: Pod
metadata:
  name: nginx
  namespace: kubeflow
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: existing-key1
            operator: In
            values:
            - existing-value1
  containers:
  - image: nginx:1.14.2
    name: nginx
    ports:
    - containerPort: 80
```

Yielded a patched version with affinity of:
```
spec:
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: existing-key1
            operator: In
            values:
            - existing-value1
        - - matchExpressions:   <---extra nesting
            - key: the-testing-key
              operator: In
              values:
              - the-testing-val1
          - matchExpressions:
            - key: the-testing-key2
              operator: In
              values:
              - the-testing-val2
```

This commit corrects this by refactoring the way patches are build such that:
* a patch is created to initialise an empty affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms array, if it does not already exist (including any parent objects required)
* N patches are created, one for each of the NodeSelectorTerms to be added (rather than a single patch that would replace the entire array)
